### PR TITLE
docs: add global handler for VenueClosedException

### DIFF
--- a/src/main/java/com/tobi/venuemgmt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tobi/venuemgmt/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 
 import java.time.LocalDateTime;
@@ -98,6 +99,19 @@ public class GlobalExceptionHandler {
         body.put("fieldErrors", fieldErrors);
 
         return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+
+    // Handler for the VenueClosedException
+    @ExceptionHandler(VenueClosedException.class)
+    public ResponseEntity<ErrorDetails> handleVenueClosedException(VenueClosedException ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(
+            LocalDateTime.now(),
+            HttpStatus.BAD_REQUEST.value(),
+            HttpStatus.BAD_REQUEST.getReasonPhrase(),
+            ex.getMessage(),
+            ((ServletWebRequest) request).getRequest().getRequestURI()
+        );
+        return new ResponseEntity<>(errorDetails, HttpStatus.BAD_REQUEST);
     }
 
     /**


### PR DESCRIPTION
- Added a new @ExceptionHandler in the controller to handle `VenueClosedException`.
- Constructs a detailed `ErrorDetails` response with timestamp, status code, error message, and request URI.
- Returns `HttpStatus.BAD_REQUEST` when a VenueClosedException is thrown.
- Improves API robustness and provides clear feedback to clients when an order is attempted on a closed venue.
